### PR TITLE
Update `temp` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "examples"
   },
   "dependencies": {
-    "temp": "~0.5.0",
+    "temp": "~0.6.0",
     "through": "~2.1.0",
     "fs-extra": "~0.3.2"
   },


### PR DESCRIPTION
Node v7.0.0 was just recently released, and [it deprecated `os.tmpDir` in favor of `os.tmpdir`](https://github.com/nodejs/node/commit/5e5ec2cd1e). Using `node-latex` right now in Node v7 will have that deprecation warning appear due to `temp` v0.5.X using `tmpDir()`. Using the `0.6.X` version of `temp` should get rid of the deprecation warning for Node v7.
