### PR TITLE
ignore stdio to avoid bufsize issue when inheriting io

### DIFF
--- a/texwrapper.js
+++ b/texwrapper.js
@@ -114,7 +114,8 @@ module.exports = function(doc, options) {
         "texput.tex"
       ], {
         cwd: dirpath,
-        env: process.env
+        env: process.env,
+        stdio: ['ignore','ignore','ignore']
       });
 
       // Let the user know if LaTeX couldn't be found


### PR DESCRIPTION
When using the module in a http server pdflatex locked up after partially processing the input, probably due to limited stdout or stderr buffer size inherited from the parent process. Setting stdio to 'ignore' resolved the issue. We don't seem to use stdio here anyway; any errors are looked up via the log file.