### PR TITLE
Update dependencies and bump patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "latex",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A simple wrapper for LaTeX in node.js",
   "main": "texwrapper.js",
   "directories": {
@@ -9,7 +9,7 @@
   "dependencies": {
     "temp": "~0.6.0",
     "through": "~2.1.0",
-    "fs-extra": "~0.3.2"
+    "fs-extra": "^3"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Installing `node-latex` from npm currently throws the following warning, which is caused by an outdated dependency-of-a-dependency:
`npm WARN deprecated graceful-fs@1.1.14: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
`

This PR updates the fs-extra dependency from 0.3.2 to ^3 and increments the patch version. fs-extra@0.3.2 depends on a deprecated package version (graceful-fs@1.1.14) that will fail on node v.7 and later; the most recent version of fs-extra depends on a current version of graceful-fs. I have bumped the patch version to reflect this.